### PR TITLE
Protocol change: broadcast when player joins pool

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -138,3 +138,13 @@ func (pi *packetInfo) announceStart() {
 		}
 	}
 }
+
+func (pi *packetInfo) broadcastJoinedPool(td *trackerData) error {
+	m := message.Signed{
+		Packet: &message.Packet{
+			Number: td.number,
+		},
+	}
+
+	return pi.broadcastAll([]*message.Signed{&m})
+}

--- a/server/messages.go
+++ b/server/messages.go
@@ -47,6 +47,8 @@ func (pi *packetInfo) processReceivedMessage() error {
 
 		if pi.tracker.getPoolSize(playerData.pool) == pi.tracker.poolSize {
 			pi.announceStart()
+		} else {
+			pi.broadcastJoinedPool(playerData)
 		}
 
 		return nil


### PR DESCRIPTION
It gets lonely waiting for others to join a pool. This changes the
protocol to broadcast a message to players in a pool when a new player
joins their pool.

This should be merged at the same time as: https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/pull/17