### PR TITLE
[Feature] Change message framing to prefix style

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	appName         = "cashshuffle"
-	version         = "0.2.0"
+	version         = "0.3.0"
 	defaultPort     = 8080
 	defaultPoolSize = 5
 )

--- a/server/proto.go
+++ b/server/proto.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/cashshuffle/cashshuffle/message"
 	"github.com/golang/protobuf/proto"
@@ -23,6 +24,8 @@ func writeMessage(conn net.Conn, msgs []*message.Signed) error {
 	if debugMode {
 		fmt.Println("[Sent]", packets)
 	}
+
+	time.Sleep(250 * time.Millisecond)
 
 	_, err = conn.Write(frameMessage(reply))
 	return err


### PR DESCRIPTION
The old message framing was really basic and just used a delimiter after each message. After discussing with @clifordsymack we decided to use a prefix system with magic bytes, the message length, then the message itself.

[magic][length][message]

The magic bytes are 0x42bcc32669467873
The length is encoded as a uint32 consisting of 4 bytes as big endian.

This is just the realization of that change. It passes the basic python test file I was sent. =)