### PR TITLE
[Feature] Add WebSocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,17 @@ Usage:
   cashshuffle [flags]
 
 Flags:
-  -a, --auto-cert string   register hostname with LetsEncrypt
-  -b, --bind-ip string     IP address to bind to
-  -c, --cert string        path to server.crt for TLS
-  -d, --debug              debug mode
-  -h, --help               help for cashshuffle
-  -k, --key string         path to server.key for TLS
-  -s, --pool-size int      pool size (default 5)
-  -p, --port int           server port (default 1337)
-  -z, --stats-port int     stats server port (default 8080)
-  -v, --version            display version
+  -a, --auto-cert string     register hostname with LetsEncrypt
+  -b, --bind-ip string       IP address to bind to
+  -c, --cert string          path to server.crt for TLS
+  -d, --debug                debug mode
+  -h, --help                 help for cashshuffle
+  -k, --key string           path to server.key for TLS
+  -s, --pool-size int        pool size (default 5)
+  -p, --port int             server port (default 1337)
+  -z, --stats-port int       stats server port (default 8080)
+  -v, --version              display version
+  -w, --websocket-port int   websocket port (default 1338)
 ```
 
 ## License

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	DisplayVersion bool   `json:"-"`
 	Port           int    `json:"port,string"`
 	StatsPort      int    `json:"stats_port,string"`
+	WebSocketPort  int    `json:"websocket_port,string"`
 	Cert           string `json:"cert"`
 	Key            string `json:"key"`
 	PoolSize       int    `json:"pool_size,string"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	appName          = "cashshuffle"
-	version          = "0.3.4"
-	defaultPort      = 1337
-	defaultStatsPort = 8080
-	defaultPoolSize  = 5
+	appName              = "cashshuffle"
+	version              = "0.3.6"
+	defaultPort          = 1337
+	defaultWebsocketPort = 1338
+	defaultStatsPort     = 8080
+	defaultPoolSize      = 5
 )
 
 // Stores configuration data.
@@ -56,6 +57,10 @@ func prepareFlags() {
 		config.Port = defaultPort
 	}
 
+	if config.WebSocketPort == 0 {
+		config.WebSocketPort = defaultWebsocketPort
+	}
+
 	if config.StatsPort == 0 {
 		config.StatsPort = defaultStatsPort
 	}
@@ -72,6 +77,8 @@ func prepareFlags() {
 		&config.DisplayVersion, "version", "v", false, "display version")
 	MainCmd.PersistentFlags().IntVarP(
 		&config.Port, "port", "p", config.Port, "server port")
+	MainCmd.PersistentFlags().IntVarP(
+		&config.WebSocketPort, "websocket-port", "w", config.WebSocketPort, "websocket port")
 	MainCmd.PersistentFlags().IntVarP(
 		&config.StatsPort, "stats-port", "z", config.StatsPort, "stats server port")
 	MainCmd.PersistentFlags().IntVarP(
@@ -105,6 +112,11 @@ func performCommand(cmd *cobra.Command, args []string) error {
 	// enable stats if port specified
 	if config.StatsPort > 0 {
 		go server.StartStatsServer(config.BindIP, config.StatsPort, config.Cert, config.Key, t, m)
+	}
+
+	// enable websocket port if specified.
+	if config.WebSocketPort > 0 {
+		go server.StartWebsocket(config.BindIP, config.WebSocketPort, config.Cert, config.Key, config.Debug, t, m)
 	}
 
 	return server.Start(config.BindIP, config.Port, config.Cert, config.Key, config.Debug, t, m)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,9 +15,9 @@ import (
 
 const (
 	appName              = "cashshuffle"
-	version              = "0.3.6"
+	version              = "0.4.0"
 	defaultPort          = 1337
-	defaultWebsocketPort = 1338
+	defaultWebSocketPort = 1338
 	defaultStatsPort     = 8080
 	defaultPoolSize      = 5
 )
@@ -58,7 +58,7 @@ func prepareFlags() {
 	}
 
 	if config.WebSocketPort == 0 {
-		config.WebSocketPort = defaultWebsocketPort
+		config.WebSocketPort = defaultWebSocketPort
 	}
 
 	if config.StatsPort == 0 {
@@ -102,7 +102,7 @@ func performCommand(cmd *cobra.Command, args []string) error {
 		return errors.New("can't specify auto-cert and key/cert")
 	}
 
-	t := server.NewTracker(config.PoolSize, config.Port)
+	t := server.NewTracker(config.PoolSize, config.Port, config.WebSocketPort)
 
 	m, err := getLetsEncryptManager()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -52,6 +52,9 @@ func StartWebsocket(ip string, port int, cert string, key string, debug bool, t 
 	go startPacketInfoChan(packetInfoChan)
 
 	var handleConnectionFunc = func(ws *websocket.Conn) {
+		// Need to enforce binary type. Text framing won't work.
+		ws.PayloadType = websocket.BinaryFrame
+
 		handleConnection(ws, packetInfoChan, t)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,13 @@ func Start(ip string, port int, cert string, key string, debug bool, t *Tracker,
 	}
 }
 
+// StartWebsocket brings up the websocket server.
+func StartWebsocket(ip string, port int, cert string, key string, debug bool, t *Tracker, m *autocert.Manager) (err error) {
+	fmt.Printf("Shuffle Listening via Websockets on %s:%d\n", ip, port)
+
+	return nil
+}
+
 func handleConnection(conn net.Conn, c chan *packetInfo, tracker *Tracker) {
 	defer conn.Close()
 	defer tracker.remove(conn)

--- a/server/stats.go
+++ b/server/stats.go
@@ -7,10 +7,11 @@ type StatsInformer interface {
 
 // TrackerStats represents a snapshot of the trackers statistics
 type TrackerStats struct {
-	Connections int         `json:"connections"`
-	PoolSize    int         `json:"poolSize"`
-	Pools       []PoolStats `json:"pools"`
-	ShufflePort int         `json:"shufflePort"`
+	Connections          int         `json:"connections"`
+	PoolSize             int         `json:"poolSize"`
+	Pools                []PoolStats `json:"pools"`
+	ShufflePort          int         `json:"shufflePort"`
+	ShuffleWebSocketPort int         `json:"shuffleWebSocketPort"`
 }
 
 // PoolStats represents the stats for a particular pool
@@ -26,10 +27,11 @@ func (t *Tracker) Stats() *TrackerStats {
 	defer t.mutex.RUnlock()
 
 	ts := &TrackerStats{
-		Connections: len(t.connections),
-		PoolSize:    t.poolSize,
-		Pools:       make([]PoolStats, 0),
-		ShufflePort: t.shufflePort,
+		Connections:          len(t.connections),
+		PoolSize:             t.poolSize,
+		Pools:                make([]PoolStats, 0),
+		ShufflePort:          t.shufflePort,
+		ShuffleWebSocketPort: t.shuffleWebSocketPort,
 	}
 
 	for k, p := range t.pools {

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -9,14 +9,15 @@ import (
 
 // Tracker is used to track connections to the server.
 type Tracker struct {
-	connections      map[net.Conn]*trackerData
-	verificationKeys map[string]net.Conn
-	mutex            sync.RWMutex
-	pools            map[int]map[uint32]interface{}
-	poolAmounts      map[int]uint64
-	poolSize         int
-	fullPools        map[int]interface{}
-	shufflePort      int
+	connections          map[net.Conn]*trackerData
+	verificationKeys     map[string]net.Conn
+	mutex                sync.RWMutex
+	pools                map[int]map[uint32]interface{}
+	poolAmounts          map[int]uint64
+	poolSize             int
+	fullPools            map[int]interface{}
+	shufflePort          int
+	shuffleWebSocketPort int
 }
 
 // trackerData is data needed about each connection.
@@ -32,15 +33,16 @@ type trackerData struct {
 }
 
 // NewTracker instantiates a new tracker
-func NewTracker(poolSize int, shufflePort int) *Tracker {
+func NewTracker(poolSize int, shufflePort int, shuffleWebSocketPort int) *Tracker {
 	return &Tracker{
-		poolSize:         poolSize,
-		connections:      make(map[net.Conn]*trackerData),
-		verificationKeys: make(map[string]net.Conn),
-		pools:            make(map[int]map[uint32]interface{}),
-		poolAmounts:      make(map[int]uint64),
-		fullPools:        make(map[int]interface{}),
-		shufflePort:      shufflePort,
+		poolSize:             poolSize,
+		connections:          make(map[net.Conn]*trackerData),
+		verificationKeys:     make(map[string]net.Conn),
+		pools:                make(map[int]map[uint32]interface{}),
+		poolAmounts:          make(map[int]uint64),
+		fullPools:            make(map[int]interface{}),
+		shufflePort:          shufflePort,
+		shuffleWebSocketPort: shuffleWebSocketPort,
 	}
 }
 


### PR DESCRIPTION
Now the server handles WebSocket connections. No more need for ws-tcp-proxy. It will even use the lets encrypt hooks to automatically setup the certs for you.

Fixes https://github.com/cashshuffle/cashshuffle/issues/19