### PR TITLE
[Feature] Add option to spin up TCP listeners for tor in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Flags:
   -p, --port int                 server port (default 1337)
   -z, --stats-port int           stats server port (default 8080)
   -t, --tor                      enable secondary listener for tor connections
-      --tor-bind-ip string       IP address to bind tor to (default "127.0.0.1")
+      --tor-bind-ip string       IP address to bind to for tor (default "127.0.0.1")
       --tor-port int             tor server port (default 1339)
       --tor-stats-port int       tor stats server port (default 8081)
       --tor-websocket-port int   tor websocket port (default 1340)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ Flags:
   -w, --websocket-port int       websocket port (default 1338)
 ```
 
+## Tor
+
+To run a server on the public internet with SSL and also support Tor just use the `--tor` flag.
+
+```
+cashshuffle -s 5 -c <cert> -k <key> --tor
+```
+
+Now edit your `torrc` and add the following. Then restart Tor for the configuration to take effect.
+
+```
+HiddenServiceDir /var/lib/tor/cashshuffle
+HiddenServicePort 1339 127.0.0.1:1339
+HiddenServicePort 1140 127.0.0.1:1140
+HiddenServicePort 8081 127.0.0.1:8081
+```
+
+For more docs on setting up onion services you can check out https://www.torproject.org/docs/tor-onion-service.html.en.
+
 ## License
 
 cashshuffle is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Now edit your `torrc` and add the following. Then restart Tor for the configurat
 ```
 HiddenServiceDir /var/lib/tor/cashshuffle
 HiddenServicePort 1339 127.0.0.1:1339
-HiddenServicePort 1140 127.0.0.1:1140
+HiddenServicePort 1340 127.0.0.1:1340
 HiddenServicePort 8081 127.0.0.1:8081
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Flags:
   -p, --port int                 server port (default 1337)
   -z, --stats-port int           stats server port (default 8080)
   -t, --tor                      enable secondary listener for tor connections
+      --tor-bind-ip string       IP address to bind tor to (default "127.0.0.1")
       --tor-port int             tor server port (default 1339)
       --tor-stats-port int       tor stats server port (default 8081)
       --tor-websocket-port int   tor websocket port (default 1340)

--- a/README.md
+++ b/README.md
@@ -43,17 +43,21 @@ Usage:
   cashshuffle [flags]
 
 Flags:
-  -a, --auto-cert string     register hostname with LetsEncrypt
-  -b, --bind-ip string       IP address to bind to
-  -c, --cert string          path to server.crt for TLS
-  -d, --debug                debug mode
-  -h, --help                 help for cashshuffle
-  -k, --key string           path to server.key for TLS
-  -s, --pool-size int        pool size (default 5)
-  -p, --port int             server port (default 1337)
-  -z, --stats-port int       stats server port (default 8080)
-  -v, --version              display version
-  -w, --websocket-port int   websocket port (default 1338)
+  -a, --auto-cert string         register hostname with LetsEncrypt
+  -b, --bind-ip string           IP address to bind to
+  -c, --cert string              path to server.crt for TLS
+  -d, --debug                    debug mode
+  -h, --help                     help for cashshuffle
+  -k, --key string               path to server.key for TLS
+  -s, --pool-size int            pool size (default 5)
+  -p, --port int                 server port (default 1337)
+  -z, --stats-port int           stats server port (default 8080)
+  -t, --tor                      enable secondary listener for tor connections
+      --tor-port int             tor server port (default 1339)
+      --tor-stats-port int       tor stats server port (default 8081)
+      --tor-websocket-port int   tor websocket port (default 1340)
+  -v, --version                  display version
+  -w, --websocket-port int       websocket port (default 1338)
 ```
 
 ## License

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,16 +11,20 @@ import (
 
 // Config stores all the application configuration.
 type Config struct {
-	DisplayVersion bool   `json:"-"`
-	Port           int    `json:"port,string"`
-	StatsPort      int    `json:"stats_port,string"`
-	WebSocketPort  int    `json:"websocket_port,string"`
-	Cert           string `json:"cert"`
-	Key            string `json:"key"`
-	PoolSize       int    `json:"pool_size,string"`
-	Debug          bool   `json:"debug,string"`
-	AutoCert       string `json:"auto_cert"`
-	BindIP         string `json:"bind_ip"`
+	DisplayVersion   bool   `json:"-"`
+	Port             int    `json:"port,string"`
+	StatsPort        int    `json:"stats_port,string"`
+	WebSocketPort    int    `json:"websocket_port,string"`
+	Cert             string `json:"cert"`
+	Key              string `json:"key"`
+	PoolSize         int    `json:"pool_size,string"`
+	Debug            bool   `json:"debug,string"`
+	AutoCert         string `json:"auto_cert"`
+	BindIP           string `json:"bind_ip"`
+	Tor              bool   `json:"tor,string"`
+	TorPort          int    `json:"tor_port,string"`
+	TorStatsPort     int    `json:"tor_stats_port,string"`
+	TorWebSocketPort int    `json:"tor_websocket_port,string"`
 }
 
 // Load reads the configuration from ~/.cashshuffle/config and loads it into the Config struct.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AutoCert         string `json:"auto_cert"`
 	BindIP           string `json:"bind_ip"`
 	Tor              bool   `json:"tor,string"`
+	TorBindIP        string `json:"tor_bind_ip"`
 	TorPort          int    `json:"tor_port,string"`
 	TorStatsPort     int    `json:"tor_stats_port,string"`
 	TorWebSocketPort int    `json:"tor_websocket_port,string"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ const (
 	defaultStatsPort        = 8080
 	defaultTorStatsPort     = 8081
 	defaultPoolSize         = 5
+	defaultTorBindIP        = "127.0.0.1"
 )
 
 // Stores configuration data.
@@ -68,6 +69,10 @@ func prepareFlags() {
 		config.StatsPort = defaultStatsPort
 	}
 
+	if config.TorBindIP == "" {
+		config.TorBindIP = defaultTorBindIP
+	}
+
 	if config.TorPort == 0 {
 		config.TorPort = defaultTorPort
 	}
@@ -106,6 +111,8 @@ func prepareFlags() {
 		&config.BindIP, "bind-ip", "b", config.BindIP, "IP address to bind to")
 	MainCmd.PersistentFlags().BoolVarP(
 		&config.Tor, "tor", "t", config.Tor, "enable secondary listener for tor connections")
+	MainCmd.PersistentFlags().StringVarP(
+		&config.TorBindIP, "tor-bind-ip", "", config.TorBindIP, "IP address to bind tor to")
 	MainCmd.PersistentFlags().IntVarP(
 		&config.TorPort, "tor-port", "", config.TorPort, "tor server port")
 	MainCmd.PersistentFlags().IntVarP(
@@ -138,7 +145,7 @@ func performCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if config.Tor && config.TorStatsPort > 0 {
-		go server.StartStatsServer("localhost", config.TorStatsPort, "", "", t, nil, true)
+		go server.StartStatsServer(config.TorBindIP, config.TorStatsPort, "", "", t, nil, true)
 	}
 
 	// enable websocket port if specified.
@@ -147,12 +154,12 @@ func performCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if config.Tor && config.TorWebSocketPort > 0 {
-		go server.StartWebsocket("localhost", config.TorWebSocketPort, "", "", config.Debug, t, nil, true)
+		go server.StartWebsocket(config.TorBindIP, config.TorWebSocketPort, "", "", config.Debug, t, nil, true)
 	}
 
 	// enable tor server if specified.
 	if config.Tor {
-		go server.Start("localhost", config.TorPort, "", "", config.Debug, t, nil, true)
+		go server.Start(config.TorBindIP, config.TorPort, "", "", config.Debug, t, nil, true)
 	}
 
 	return server.Start(config.BindIP, config.Port, config.Cert, config.Key, config.Debug, t, m, false)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,7 +112,7 @@ func prepareFlags() {
 	MainCmd.PersistentFlags().BoolVarP(
 		&config.Tor, "tor", "t", config.Tor, "enable secondary listener for tor connections")
 	MainCmd.PersistentFlags().StringVarP(
-		&config.TorBindIP, "tor-bind-ip", "", config.TorBindIP, "IP address to bind tor to")
+		&config.TorBindIP, "tor-bind-ip", "", config.TorBindIP, "IP address to bind to for tor")
 	MainCmd.PersistentFlags().IntVarP(
 		&config.TorPort, "tor-port", "", config.TorPort, "tor server port")
 	MainCmd.PersistentFlags().IntVarP(

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ import (
 var debugMode bool
 
 // Start brings up the TCP server.
-func Start(ip string, port int, cert string, key string, debug bool, t *Tracker, m *autocert.Manager) (err error) {
+func Start(ip string, port int, cert string, key string, debug bool, t *Tracker, m *autocert.Manager, tor bool) (err error) {
 	var listener net.Listener
 
 	debugMode = debug
@@ -36,7 +36,12 @@ func Start(ip string, port int, cert string, key string, debug bool, t *Tracker,
 	packetInfoChan := make(chan *packetInfo)
 	go startPacketInfoChan(packetInfoChan)
 
-	fmt.Printf("Shuffle Listening on TCP %s:%d (pool size: %d)\n", ip, port, t.poolSize)
+	torStr := ""
+	if tor {
+		torStr = "Tor"
+	}
+
+	fmt.Printf("%sShuffle Listening on TCP %s:%d (pool size: %d)\n", torStr, ip, port, t.poolSize)
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -48,7 +53,7 @@ func Start(ip string, port int, cert string, key string, debug bool, t *Tracker,
 }
 
 // StartWebsocket brings up the websocket server.
-func StartWebsocket(ip string, port int, cert string, key string, debug bool, t *Tracker, m *autocert.Manager) (err error) {
+func StartWebsocket(ip string, port int, cert string, key string, debug bool, t *Tracker, m *autocert.Manager, tor bool) (err error) {
 	packetInfoChan := make(chan *packetInfo)
 	go startPacketInfoChan(packetInfoChan)
 
@@ -78,7 +83,12 @@ func StartWebsocket(ip string, port int, cert string, key string, debug bool, t 
 		srv.TLSConfig.GetCertificate = m.GetCertificate
 	}
 
-	fmt.Printf("Shuffle Listening via Websockets on %s:%d\n", ip, port)
+	torStr := ""
+	if tor {
+		torStr = "Tor"
+	}
+
+	fmt.Printf("%sShuffle Listening via Websockets on %s:%d\n", torStr, ip, port)
 
 	if tlsEnabled(cert, key, m) {
 		err = srv.ListenAndServeTLS(cert, key)

--- a/server/stats.go
+++ b/server/stats.go
@@ -2,7 +2,7 @@ package server
 
 // StatsInformer defines an interface that exposes tracker stats
 type StatsInformer interface {
-	Stats(string) *TrackerStats
+	Stats(string, bool) *TrackerStats
 }
 
 // TrackerStats represents a snapshot of the trackers statistics
@@ -26,7 +26,7 @@ type PoolStats struct {
 }
 
 // Stats returns the tracker stats.
-func (t *Tracker) Stats(ip string) *TrackerStats {
+func (t *Tracker) Stats(ip string, tor bool) *TrackerStats {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
@@ -41,14 +41,24 @@ func (t *Tracker) Stats(ip string) *TrackerStats {
 		}
 	}
 
+	sp := t.shufflePort
+	if tor {
+		sp = t.torShufflePort
+	}
+
+	wssp := t.shuffleWebSocketPort
+	if tor {
+		wssp = t.torShuffleWebSocketPort
+	}
+
 	ts := &TrackerStats{
 		BanScore:             banScore,
 		Banned:               banned,
 		Connections:          len(t.connections),
 		PoolSize:             t.poolSize,
 		Pools:                make([]PoolStats, 0),
-		ShufflePort:          t.shufflePort,
-		ShuffleWebSocketPort: t.shuffleWebSocketPort,
+		ShufflePort:          sp,
+		ShuffleWebSocketPort: wssp,
 	}
 
 	for k, p := range t.pools {

--- a/server/stats_test.go
+++ b/server/stats_test.go
@@ -50,8 +50,11 @@ func TestTrackStats(t *testing.T) {
 		fullPools: map[int]interface{}{
 			1: nil,
 		},
-		poolSize:    5,
-		shufflePort: 3000,
+		poolSize:                5,
+		shufflePort:             3000,
+		shuffleWebSocketPort:    3001,
+		torShufflePort:          3002,
+		torShuffleWebSocketPort: 3003,
 		bannedIPs: map[string]*banData{
 			"8.8.8.8": {
 				score: maxBanScore,
@@ -63,7 +66,7 @@ func TestTrackStats(t *testing.T) {
 	}
 
 	// Test with ban.
-	stats := tracker.Stats("8.8.8.8")
+	stats := tracker.Stats("8.8.8.8", false)
 
 	assert.Equal(t, uint32(3), stats.BanScore)
 	assert.Equal(t, true, stats.Banned)
@@ -71,6 +74,7 @@ func TestTrackStats(t *testing.T) {
 	assert.Equal(t, 5, stats.PoolSize)
 	assert.Equal(t, 2, len(stats.Pools))
 	assert.Equal(t, 3000, stats.ShufflePort)
+	assert.Equal(t, 3001, stats.ShuffleWebSocketPort)
 	assert.Contains(t, stats.Pools,
 		PoolStats{
 			Members: 5,
@@ -89,14 +93,15 @@ func TestTrackStats(t *testing.T) {
 	)
 
 	// Test without ban.
-	stats2 := tracker.Stats("8.8.4.4")
+	stats2 := tracker.Stats("8.8.4.4", true)
 
 	assert.Equal(t, uint32(2), stats2.BanScore)
 	assert.Equal(t, false, stats2.Banned)
 	assert.Equal(t, 8, stats2.Connections)
 	assert.Equal(t, 5, stats2.PoolSize)
 	assert.Equal(t, 2, len(stats2.Pools))
-	assert.Equal(t, 3000, stats2.ShufflePort)
+	assert.Equal(t, 3002, stats2.ShufflePort)
+	assert.Equal(t, 3003, stats2.ShuffleWebSocketPort)
 	assert.Contains(t, stats2.Pools,
 		PoolStats{
 			Members: 5,

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -23,18 +23,20 @@ const (
 
 // Tracker is used to track connections to the server.
 type Tracker struct {
-	bannedIPs            map[string]*banData
-	connections          map[net.Conn]*trackerData
-	verificationKeys     map[string]net.Conn
-	mutex                sync.RWMutex
-	pools                map[int]map[uint32]interface{}
-	poolAmounts          map[int]uint64
-	poolVersions         map[int]uint64
-	poolTypes            map[int]message.ShuffleType
-	poolSize             int
-	fullPools            map[int]interface{}
-	shufflePort          int
-	shuffleWebSocketPort int
+	bannedIPs               map[string]*banData
+	connections             map[net.Conn]*trackerData
+	verificationKeys        map[string]net.Conn
+	mutex                   sync.RWMutex
+	pools                   map[int]map[uint32]interface{}
+	poolAmounts             map[int]uint64
+	poolVersions            map[int]uint64
+	poolTypes               map[int]message.ShuffleType
+	poolSize                int
+	fullPools               map[int]interface{}
+	shufflePort             int
+	shuffleWebSocketPort    int
+	torShufflePort          int
+	torShuffleWebSocketPort int
 }
 
 // banData is the data required to track IP bans.
@@ -57,19 +59,21 @@ type trackerData struct {
 }
 
 // NewTracker instantiates a new tracker
-func NewTracker(poolSize int, shufflePort int, shuffleWebSocketPort int) *Tracker {
+func NewTracker(poolSize int, shufflePort int, shuffleWebSocketPort int, torShufflePort int, torShuffleWebSocketPort int) *Tracker {
 	return &Tracker{
-		poolSize:             poolSize,
-		bannedIPs:            make(map[string]*banData),
-		connections:          make(map[net.Conn]*trackerData),
-		verificationKeys:     make(map[string]net.Conn),
-		pools:                make(map[int]map[uint32]interface{}),
-		poolAmounts:          make(map[int]uint64),
-		poolVersions:         make(map[int]uint64),
-		poolTypes:            make(map[int]message.ShuffleType),
-		fullPools:            make(map[int]interface{}),
-		shufflePort:          shufflePort,
-		shuffleWebSocketPort: shuffleWebSocketPort,
+		poolSize:                poolSize,
+		bannedIPs:               make(map[string]*banData),
+		connections:             make(map[net.Conn]*trackerData),
+		verificationKeys:        make(map[string]net.Conn),
+		pools:                   make(map[int]map[uint32]interface{}),
+		poolAmounts:             make(map[int]uint64),
+		poolVersions:            make(map[int]uint64),
+		poolTypes:               make(map[int]message.ShuffleType),
+		fullPools:               make(map[int]interface{}),
+		shufflePort:             shufflePort,
+		shuffleWebSocketPort:    shuffleWebSocketPort,
+		torShufflePort:          torShufflePort,
+		torShuffleWebSocketPort: torShuffleWebSocketPort,
 	}
 }
 


### PR DESCRIPTION
Now the cashshuffle server can spin up a second TCP listener for tor connections.

The following options have been added.
```
  -t, --tor                      enable secondary listener for tor connections
      --tor-bind-ip string       IP address to bind to for tor (default "127.0.0.1")
      --tor-port int             tor server port (default 1339)
      --tor-stats-port int       tor stats server port (default 8081)
      --tor-websocket-port int   tor websocket port (default 1340)
```

Sample output:
```
tor ✔ $ ./cashshuffle --tor
TorStats Listening on TCP 127.0.0.1:8081 (tls: false)
Shuffle Listening on TCP :1337 (pool size: 5)
TorShuffle Listening via Websockets on 127.0.0.1:1340
TorShuffle Listening on TCP 127.0.0.1:1339 (pool size: 5)
Stats Listening on TCP :8080 (tls: false)
Shuffle Listening via Websockets on :1338
```

Notice the secondary listener is listening on 127.0.0.1. The ip can be configured, but it is not required to serve tor clients in most setups.

The main feature this brings, is that tor users and normal users share the same pools and can shuffle with each other. This allows for shuffles to happen faster, and connect more users together rather than have different services with different pool sets.

To expose the service you need to edit your `torrc` file. Here is what you would need to add:
```
HiddenServiceDir /var/lib/tor/cashshuffle
HiddenServicePort 1339 127.0.0.1:1339
HiddenServicePort 1340 127.0.0.1:1340
HiddenServicePort 8081 127.0.0.1:8081
```

For more docs on setting up onion services you can check out https://www.torproject.org/docs/tor-onion-service.html.en

To make it more convenient for stats endpoint clients, the server port and web socket port are served correctly based on the interface the request comes in. That way no json schema changes were required and integration with wallet software stays consistent.