### PR TITLE
[Bug] Allow multiple blames to be handled correctly

### DIFF
--- a/server/banned.go
+++ b/server/banned.go
@@ -36,9 +36,10 @@ func (pi *packetInfo) checkBanMessage() error {
 			return nil
 		}
 
-		bannedTrackerData.mutex.Lock()
-		bannedTrackerData.bannedBy[td.verificationKey] = nil
-		bannedTrackerData.mutex.Unlock()
+		added := bannedTrackerData.addBannedBy(td.verificationKey)
+		if !added {
+			return nil
+		}
 
 		if pi.tracker.banned(bannedTrackerData) {
 			pi.tracker.banIP(bannedTrackerData.conn)

--- a/server/banned.go
+++ b/server/banned.go
@@ -36,6 +36,10 @@ func (pi *packetInfo) checkBanMessage() error {
 			return nil
 		}
 
+		if bannedTrackerData.pool != td.pool {
+			return errors.New("invalid ban")
+		}
+
 		added := bannedTrackerData.addBannedBy(td.verificationKey)
 		if !added {
 			return nil

--- a/server/banned.go
+++ b/server/banned.go
@@ -37,11 +37,12 @@ func (pi *packetInfo) checkBanMessage() error {
 		}
 
 		bannedTrackerData.mutex.Lock()
-		defer bannedTrackerData.mutex.Unlock()
 		bannedTrackerData.bannedBy[td.verificationKey] = nil
+		bannedTrackerData.mutex.Unlock()
 
 		if pi.tracker.banned(bannedTrackerData) {
 			pi.tracker.banIP(bannedTrackerData.conn)
+			pi.tracker.decreasePoolSize(td.pool)
 		}
 
 		return errors.New("player banned")

--- a/server/banned.go
+++ b/server/banned.go
@@ -28,7 +28,7 @@ func (pi *packetInfo) checkBanMessage() error {
 		bannedTrackerData := pi.tracker.getVerificationKeyData(banKey)
 
 		if bannedTrackerData == nil {
-			return errors.New("invalid ban")
+			return nil
 		}
 
 		td := pi.tracker.getTrackerData(pi.conn)

--- a/server/banned.go
+++ b/server/banned.go
@@ -6,6 +6,10 @@ import (
 	"github.com/cashshuffle/cashshuffle/message"
 )
 
+const (
+	playerBannedErrorMessage = "player banned"
+)
+
 // checkBanMessage checks to see if the player has sent a ban.
 func (pi *packetInfo) checkBanMessage() error {
 	if len(pi.message.Packet) != 1 {
@@ -50,7 +54,7 @@ func (pi *packetInfo) checkBanMessage() error {
 			pi.tracker.decreasePoolSize(td.pool)
 		}
 
-		return errors.New("player banned")
+		return errors.New(playerBannedErrorMessage)
 	}
 
 	return nil

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -61,8 +61,8 @@ func (pi *packetInfo) broadcastMessage() error {
 
 // broadcastAll broadcasts to all participants.
 func (pi *packetInfo) broadcastAll(msgs []*message.Signed) error {
-	pi.tracker.mutex.Lock()
-	defer pi.tracker.mutex.Unlock()
+	pi.tracker.mutex.RLock()
+	defer pi.tracker.mutex.RUnlock()
 
 	playerData := pi.tracker.connections[pi.conn]
 
@@ -89,8 +89,8 @@ func (pi *packetInfo) broadcastAll(msgs []*message.Signed) error {
 // broadcastNewRound broadcasts a new round.
 func (pi *packetInfo) broadcastNewRound(lock bool) {
 	if lock {
-		pi.tracker.mutex.Lock()
-		defer pi.tracker.mutex.Unlock()
+		pi.tracker.mutex.RLock()
+		defer pi.tracker.mutex.RUnlock()
 	}
 
 	playerData := pi.tracker.connections[pi.conn]
@@ -126,8 +126,8 @@ func (pi *packetInfo) broadcastNewRound(lock bool) {
 // announceStart sends an annoucement message if the pool
 // is full.
 func (pi *packetInfo) announceStart() {
-	pi.tracker.mutex.Lock()
-	defer pi.tracker.mutex.Unlock()
+	pi.tracker.mutex.RLock()
+	defer pi.tracker.mutex.RUnlock()
 
 	playerData := pi.tracker.connections[pi.conn]
 

--- a/server/messages.go
+++ b/server/messages.go
@@ -71,7 +71,7 @@ func (pi *packetInfo) processReceivedMessage() error {
 	}
 
 	if err := pi.checkBanMessage(); err != nil {
-		if err.Error() == "player banned!" {
+		if err.Error() == "player banned" {
 			return nil
 		}
 		return err

--- a/server/messages.go
+++ b/server/messages.go
@@ -71,7 +71,7 @@ func (pi *packetInfo) processReceivedMessage() error {
 	}
 
 	if err := pi.checkBanMessage(); err != nil {
-		if err.Error() == "player banned" {
+		if err.Error() == playerBannedErrorMessage {
 			return nil
 		}
 		return err

--- a/server/register.go
+++ b/server/register.go
@@ -23,6 +23,7 @@ func (pi *packetInfo) registerClient() error {
 					amount:          registration.GetAmount(),
 					shuffleType:     registration.GetType(),
 					version:         registration.GetVersion(),
+					poolSize:        pi.tracker.poolSize,
 				}
 				pi.tracker.add(&td)
 

--- a/server/register.go
+++ b/server/register.go
@@ -23,7 +23,6 @@ func (pi *packetInfo) registerClient() error {
 					amount:          registration.GetAmount(),
 					shuffleType:     registration.GetType(),
 					version:         registration.GetVersion(),
-					poolSize:        pi.tracker.poolSize,
 				}
 				pi.tracker.add(&td)
 

--- a/server/stats_test.go
+++ b/server/stats_test.go
@@ -21,7 +21,7 @@ func TestTrackStats(t *testing.T) {
 			&fakeConn{}: {},
 			&fakeConn{}: {},
 		},
-		pools: map[int]map[uint32]interface{}{
+		pools: map[int]map[uint32]*trackerData{
 			1: {
 				1: nil,
 				2: nil,

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -111,7 +111,7 @@ func (t *Tracker) remove(conn net.Conn) {
 
 // banned returns true if the player has been banned.
 func (t *Tracker) banned(data *trackerData) bool {
-	return t.poolSize == (len(data.bannedBy) + 1)
+	return data.poolSize <= (len(data.bannedBy) + 1)
 }
 
 // count returns the number of connections to the server.

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -84,6 +84,7 @@ func (t *Tracker) remove(conn net.Conn) {
 
 	td := t.connections[conn]
 	if td != nil {
+		verificationKey := td.verificationKey
 		// Remove the verification key after 15 seconds. This prevents
 		// an error when a user disconnects right after the blame cycle
 		// starts.
@@ -93,8 +94,8 @@ func (t *Tracker) remove(conn net.Conn) {
 			t.mutex.Lock()
 			defer t.mutex.Unlock()
 
-			if td.verificationKey != "" {
-				delete(t.verificationKeys, td.verificationKey)
+			if verificationKey != "" {
+				delete(t.verificationKeys, verificationKey)
 			}
 		}()
 

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -111,6 +111,9 @@ func (t *Tracker) remove(conn net.Conn) {
 
 // banned returns true if the player has been banned.
 func (t *Tracker) banned(data *trackerData) bool {
+	data.mutex.Lock()
+	defer data.mutex.Unlock()
+
 	return data.poolSize <= (len(data.bannedBy) + 1)
 }
 

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -268,11 +268,15 @@ func (t *Tracker) assignPool(data *trackerData) (int, uint32) {
 
 // decreasePoolSize decreases the pool size being
 // tracked in trackerData after a blame occurs.
-func(t *Tracker) decreasePoolSize(pool int) {
+func (t *Tracker) decreasePoolSize(pool int) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
 	for _, td := range t.pools[pool] {
+		if td == nil {
+			continue
+		}
+
 		td.mutex.Lock()
 		defer td.mutex.Unlock()
 

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -266,6 +266,20 @@ func (t *Tracker) assignPool(data *trackerData) (int, uint32) {
 	return num, playerNum
 }
 
+// decreasePoolSize decreases the pool size being
+// tracked in trackerData after a blame occurs.
+func(t *Tracker) decreasePoolSize(pool int) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	for _, td := range t.pools[pool] {
+		td.mutex.Lock()
+		defer td.mutex.Unlock()
+
+		td.poolSize--
+	}
+}
+
 // unassignPool removes a user from a pool.
 // This method assumes the caller is holding the mutex.
 func (t *Tracker) unassignPool(td *trackerData) {

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -46,7 +46,7 @@ type banData struct {
 
 // trackerData is data needed about each connection.
 type trackerData struct {
-	mutex           sync.Mutex
+	mutex           sync.RWMutex
 	sessionID       []byte
 	number          uint32
 	conn            net.Conn
@@ -111,24 +111,24 @@ func (t *Tracker) remove(conn net.Conn) {
 
 // banned returns true if the player has been banned.
 func (t *Tracker) banned(data *trackerData) bool {
-	data.mutex.Lock()
-	defer data.mutex.Unlock()
+	data.mutex.RLock()
+	defer data.mutex.RUnlock()
 
 	return data.poolSize <= (len(data.bannedBy) + 1)
 }
 
 // count returns the number of connections to the server.
 func (t *Tracker) count() int {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	return len(t.connections)
 }
 
 // bannedIP returns true if the player has been banned from the server.
 func (t *Tracker) bannedIP(conn net.Conn) bool {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	ip, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 
@@ -177,8 +177,8 @@ func (t *Tracker) cleanupBan(ip string) {
 
 // getVerifcationKeyConn gets the connection for a verification key.
 func (t *Tracker) getVerificationKeyData(key string) *trackerData {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	if _, ok := t.verificationKeys[key]; ok {
 		return t.connections[t.verificationKeys[key]]
@@ -189,16 +189,16 @@ func (t *Tracker) getVerificationKeyData(key string) *trackerData {
 
 // getTrackerdData returns trackerdata associated with a connection.
 func (t *Tracker) getTrackerData(c net.Conn) *trackerData {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	return t.connections[c]
 }
 
 // getPoolSize returns the pool size for the connection.
 func (t *Tracker) getPoolSize(pool int) int {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	return len(t.pools[pool])
 }
@@ -272,8 +272,8 @@ func (t *Tracker) assignPool(data *trackerData) (int, uint32) {
 // decreasePoolSize decreases the pool size being
 // tracked in trackerData after a blame occurs.
 func (t *Tracker) decreasePoolSize(pool int) {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 
 	for _, td := range t.pools[pool] {
 		if td == nil {

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -84,20 +84,9 @@ func (t *Tracker) remove(conn net.Conn) {
 
 	td := t.connections[conn]
 	if td != nil {
-		verificationKey := td.verificationKey
-		// Remove the verification key after 15 seconds. This prevents
-		// an error when a user disconnects right after the blame cycle
-		// starts.
-		go func() {
-			time.Sleep(15 * time.Second)
-
-			t.mutex.Lock()
-			defer t.mutex.Unlock()
-
-			if verificationKey != "" {
-				delete(t.verificationKeys, verificationKey)
-			}
-		}()
+		if td.verificationKey != "" {
+			delete(t.verificationKeys, td.verificationKey)
+		}
 
 		t.unassignPool(td)
 

--- a/server/tracker_data.go
+++ b/server/tracker_data.go
@@ -15,7 +15,6 @@ type trackerData struct {
 	conn            net.Conn
 	verificationKey string
 	pool            int
-	poolSize        int
 	bannedBy        map[string]interface{}
 	amount          uint64
 	version         uint64

--- a/server/tracker_data.go
+++ b/server/tracker_data.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net"
+	"sync"
+
+	"github.com/cashshuffle/cashshuffle/message"
+)
+
+// trackerData is data needed about each connection.
+type trackerData struct {
+	mutex           sync.RWMutex
+	sessionID       []byte
+	number          uint32
+	conn            net.Conn
+	verificationKey string
+	pool            int
+	poolSize        int
+	bannedBy        map[string]interface{}
+	amount          uint64
+	version         uint64
+	shuffleType     message.ShuffleType
+}
+
+// addBannedBy adds a verification key to the bannedBy map.
+func (td *trackerData) addBannedBy(verificationKey string) bool {
+	td.mutex.Lock()
+	defer td.mutex.Unlock()
+
+	if _, ok := td.bannedBy[verificationKey]; ok {
+		return false
+	}
+
+	td.bannedBy[verificationKey] = nil
+
+	return true
+}


### PR DESCRIPTION
Currently the blame logic only worked for the first person in a shuffle being blamed. It didn't actually stop messages from the second or third round of blames if they occurred.

This PR changes a few things.

1) The pool now tracks its own size. If a user gets fully blamed then the pool size will shrink. This is tracked on the trackerData.

2) We now track each trackerData object in the pool tracking.

3) We now use the pool size from the trackerData to see if they have hit the ban threshold.

The new logic should make sure we are implementing the bans correctly.