### PR TITLE
Extend pool survival deadline

### DIFF
--- a/server/proto.go
+++ b/server/proto.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	deadline = 120 * time.Second
+	deadline = 180 * time.Second
 )
 
 // writeMessage writes a *message.Signed to the connection via protobuf.


### PR DESCRIPTION
Considering clients have a 1 minute timeout, a 2-minute timeout at pools might create hardships at larger ringsizes, which we have witnessed close to ringsize 15. Extending the dissolution timeout should allow better match probability without exposing to malicious players too much.