### PR TITLE
Lower bantime on blamed clients

### DIFF
--- a/server/tracker.go
+++ b/server/tracker.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// banTime is the amount of time to ban an IP.
-	banTime = 30 * time.Minute
+	banTime = 15 * time.Minute
 
 	// banScoreTick is the ban score increment on each pool ban.
 	banScoreTick = 1


### PR DESCRIPTION
This is to address #26 ; A lower bantime should make situations less sticky if attackers temporarily become majority of pools.