### PR TITLE
Handle server errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,9 +211,8 @@ func getLetsEncryptManager() (*autocert.Manager, error) {
 }
 
 func handleServerErrors(c chan error) {
-	for err := range c {
-		if err != nil {
-			bail(err)
-		}
+	err := <- c
+	if err != nil {
+		bail(err)
 	}
 }


### PR DESCRIPTION
Proposal for #28 

I tried to keep the first change minimal - I believe this should behave exactly as before except any of the servers can cause it to exit now.

- any server returns with `nil` error --> no complaint but app finishes
- any server return For example, if any server returns without an error, it will not complain but the whole app will shut down.

I avoided changing signatures by just collecting the errors. It also seems reasonable to assume that the server handles internal errors cohesively and wouldn't need to throw out multiple unhandled errors. Is that a good assumption?

I think the next step would be deciding the logic for restarting each server vs. giving up and letting the app shut down.

If you have any feedback or requests, I can make the changes.