### PR TITLE
Fix find existing pool

### DIFF
--- a/server/tracker.go
+++ b/server/tracker.go
@@ -201,60 +201,68 @@ func (t *Tracker) generateSessionID() []byte {
 // assignPool assigns a user to a pool.
 // This method assumes the caller is holding the mutex.
 func (t *Tracker) assignPool(data *trackerData) (int, uint32) {
-	num := 1
-
-	for {
-		if _, ok := t.pools[num]; ok {
-			if t.poolAmounts[num] != data.amount {
-				num = num + 1
-				continue
-			}
-
-			if t.poolVersions[num] != data.version {
-				num = num + 1
-				continue
-			}
-
-			if t.poolTypes[num] != data.shuffleType {
-				num = num + 1
-				continue
-			}
-
-			if _, ok := t.fullPools[num]; ok {
-				num = num + 1
-				continue
-			}
-		}
-
-		break
-	}
-
-	playerNum := uint32(1)
-	if _, ok := t.pools[num]; !ok {
+	num, playerNum, found := t.getAvailableSlot(data)
+	if !found {
+		num = t.getEmptyPool()
+		playerNum = uint32(1)
 		t.pools[num] = make(map[uint32]*trackerData)
-		t.pools[num][1] = data
 		t.poolAmounts[num] = data.amount
 		t.poolSizes[num] = t.poolSize
 		t.poolVersions[num] = data.version
 		t.poolTypes[num] = data.shuffleType
-	} else {
-		for {
-			if _, ok := t.pools[num][playerNum]; ok {
-				playerNum = playerNum + 1
-				continue
-			}
-
-			break
-		}
-
-		t.pools[num][playerNum] = data
 	}
+	t.pools[num][playerNum] = data
 
 	if len(t.pools[num]) == t.poolSize {
 		t.fullPools[num] = nil
 	}
 
 	return num, playerNum
+}
+
+// getAvailableSlot finds an existing pool and open player slot for player data
+func (t *Tracker) getAvailableSlot(data *trackerData) (int, uint32, bool) {
+	for num := range t.pools {
+		if t.poolAmounts[num] != data.amount {
+			continue
+		}
+
+		if t.poolVersions[num] != data.version {
+			continue
+		}
+
+		if t.poolTypes[num] != data.shuffleType {
+			continue
+		}
+
+		if _, ok := t.fullPools[num]; ok {
+			continue
+		}
+
+		// find a slot in the available pool
+		playerNum := uint32(1)
+		for {
+			if _, ok := t.pools[num][playerNum]; ok {
+				playerNum = playerNum + 1
+				continue
+			}
+			break
+		}
+
+		return num, playerNum, true
+	}
+	return 0, 0, false
+}
+
+// getEmptyPool finds the lowest empty pool number >=1
+func (t *Tracker) getEmptyPool() int {
+	num := 1
+	for {
+		if _, ok := t.pools[num]; !ok {
+			return num
+		}
+		num++
+	}
 }
 
 // decreasePoolSize decreases the pool size being

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -19,6 +19,12 @@ const (
 	// maxBanScore is the score the connection much reach to
 	// be banned by IP.
 	maxBanScore = 3
+
+	// firstPoolNum is the starting number for pools
+	firstPoolNum = 1
+
+	// firstPlayerNum is the starting number for players in a pool
+	firstPlayerNum = uint32(1)
 )
 
 // Tracker is used to track connections to the server.
@@ -204,7 +210,7 @@ func (t *Tracker) assignPool(data *trackerData) (int, uint32) {
 	num, playerNum, found := t.getAvailableSlot(data)
 	if !found {
 		num = t.getEmptyPool()
-		playerNum = uint32(1)
+		playerNum = firstPlayerNum
 		t.pools[num] = make(map[uint32]*trackerData)
 		t.poolAmounts[num] = data.amount
 		t.poolSizes[num] = t.poolSize
@@ -240,7 +246,7 @@ func (t *Tracker) getAvailableSlot(data *trackerData) (int, uint32, bool) {
 		}
 
 		// find a slot in the available pool
-		playerNum := uint32(1)
+		playerNum := firstPlayerNum
 		for {
 			if _, ok := t.pools[num][playerNum]; ok {
 				playerNum = playerNum + 1
@@ -256,7 +262,7 @@ func (t *Tracker) getAvailableSlot(data *trackerData) (int, uint32, bool) {
 
 // getEmptyPool finds the lowest empty pool number >=1
 func (t *Tracker) getEmptyPool() int {
-	num := 1
+	num := firstPoolNum
 	for {
 		if _, ok := t.pools[num]; !ok {
 			return num


### PR DESCRIPTION
As I understand it, there are 2 bugs of the same class.

1. server fails to reuse available pools slot if it finds an empty pool slot before the available one
    - --> makes a duplicate-spec pool inappropriately
2. server fails to reuse available player slot if it finds an empty player slot before the available one
    - --> clobbers existing pool data

This fixes both of them and hopefully makes the logic easier for future devs to follow / change. It separates the existing / new logic into separate items so that each search is doing only one thing instead of two.

I also replaced the "1" magic numbers with constants for safety since they are used in more than one place.