### PR TITLE
[Feature] Filter pool entry by ip based on previous pool bans

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cashshuffle/cashshuffle/server"
 
@@ -134,6 +135,14 @@ func performCommand(cmd *cobra.Command, args []string) chan error {
 	}
 
 	t := server.NewTracker(config.PoolSize, config.Port, config.WebSocketPort, config.TorPort, config.TorWebSocketPort)
+
+	cleanupDeniedTicker := time.NewTicker(time.Minute)
+	defer cleanupDeniedTicker.Stop()
+	go func() {
+		for range cleanupDeniedTicker.C {
+			t.CleanupDeniedByIPMatch()
+		}
+	}()
 
 	m, err := getLetsEncryptManager()
 	if err != nil {

--- a/server/banned.go
+++ b/server/banned.go
@@ -48,6 +48,7 @@ func (pi *packetInfo) checkBlameMessage() error {
 		if pi.tracker.bannedByPool(accused) {
 			pi.tracker.increaseBanScore(accused.conn)
 			pi.tracker.decreasePoolVoters(blamer.pool)
+			pi.tracker.addDenyIPMatch(blamer.conn, blamer.pool)
 		}
 	}
 

--- a/server/stats_test.go
+++ b/server/stats_test.go
@@ -22,6 +22,7 @@ func TestTrackStats(t *testing.T) {
 			&fakeConn{}: {},
 			&fakeConn{}: {},
 		},
+		denyIPMatch: map[string]map[string]time.Time{},
 		pools: map[int]map[uint32]*playerData{
 			1: {
 				1: nil,
@@ -69,7 +70,7 @@ func TestTrackStats(t *testing.T) {
 	// Test with ban.
 	stats := tracker.Stats("8.8.8.8", false)
 
-	assert.Equal(t, uint32(3), stats.BanScore)
+	assert.Equal(t, uint32(5), stats.BanScore)
 	assert.Equal(t, true, stats.Banned)
 	assert.Equal(t, 8, stats.Connections)
 	assert.Equal(t, 5, stats.PoolSize)
@@ -96,7 +97,7 @@ func TestTrackStats(t *testing.T) {
 	// Test without ban.
 	stats2 := tracker.Stats("8.8.4.4", true)
 
-	assert.Equal(t, uint32(2), stats2.BanScore)
+	assert.Equal(t, uint32(4), stats2.BanScore)
 	assert.Equal(t, false, stats2.Banned)
 	assert.Equal(t, 8, stats2.Connections)
 	assert.Equal(t, 5, stats2.PoolSize)

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -165,8 +165,8 @@ func (t *Tracker) addDenyIPMatch(player1 net.Conn, pool int) {
 	}
 }
 
-// deniedByIPMatch returns if two IPs should be allowed in the same
-// pool. Caller should hold the mutex.
+// deniedByIPMatch returns true if an IP should be denied access to a pool.
+// Caller should hold the mutex.
 func (t *Tracker) deniedByIPMatch(player net.Conn, pool int) bool {
 	ip, _, _ := net.SplitHostPort(player.RemoteAddr().String())
 	if _, ok := t.denyIPMatch[ip]; !ok {

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -137,8 +137,8 @@ func (t *Tracker) bannedByServer(conn net.Conn) bool {
 	return false
 }
 
-// addDenyIPMatch prevents two ips from joining the same pool for
-// a timeout period.
+// addDenyIPMatch prevents an IP from joining a pool with the other
+// pool member IPs for a timeout period.
 func (t *Tracker) addDenyIPMatch(player1 net.Conn, pool int) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -14,6 +14,10 @@ const (
 	// banTime is the amount of time to ban an IP.
 	banTime = 15 * time.Minute
 
+	// denyIPTime is the amount of time to avoid matching with other
+	// IPs that have banned you from pools in the past.
+	denyIPTime = 2 * time.Hour
+
 	// banScoreTick is the ban score increment on each pool ban.
 	banScoreTick = 1
 
@@ -190,7 +194,7 @@ func (t *Tracker) CleanupDeniedByIPMatch() {
 
 	for ip, deniedIPs := range t.denyIPMatch {
 		for deniedIP, deniedTime := range deniedIPs {
-			if deniedTime.Add(banTime).Before(time.Now()) {
+			if deniedTime.Add(denyIPTime).Before(time.Now()) {
 				delete(t.denyIPMatch[ip], deniedIP)
 			}
 		}


### PR DESCRIPTION
Inspired by https://github.com/cashshuffle/cashshuffle/issues/26

This implements a few new rules:
- When a user is banned from a pool, the ips are now saved so they won't match in another pool for 15 minutes.
- The full server IP ban now occurs after 5 failed shuffles instead of 3.

This is a starting point for more discussion. Lets hear it. =)


