### PR TITLE
alternative ip lookup

### DIFF
--- a/server/stats_test.go
+++ b/server/stats_test.go
@@ -22,7 +22,7 @@ func TestTrackStats(t *testing.T) {
 			&fakeConn{}: {},
 			&fakeConn{}: {},
 		},
-		denyIPMatch: map[string]map[string]time.Time{},
+		denyIPMatch: map[ipPair]time.Time{},
 		pools: map[int]map[uint32]*playerData{
 			1: {
 				1: nil,

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -38,7 +38,7 @@ type Tracker struct {
 	connections             map[net.Conn]*playerData
 	verificationKeys        map[string]net.Conn
 	mutex                   sync.RWMutex
-	denyIPMatch             map[string]map[string]time.Time
+	denyIPMatch             map[ipPair]time.Time
 	pools                   map[int]map[uint32]*playerData
 	poolAmounts             map[int]uint64
 	poolVoters              map[int]int
@@ -57,6 +57,19 @@ type banData struct {
 	score uint32
 }
 
+// ipPair is a canonically sorted pair of IPs
+type ipPair struct {
+	left  string
+	right string
+}
+
+func newIPPair(a, b string) ipPair {
+	if a < b {
+		return ipPair{a, b}
+	}
+	return ipPair{b, a}
+}
+
 // NewTracker instantiates a new tracker
 func NewTracker(poolSize int, shufflePort int, shuffleWebSocketPort int, torShufflePort int, torShuffleWebSocketPort int) *Tracker {
 	return &Tracker{
@@ -64,7 +77,7 @@ func NewTracker(poolSize int, shufflePort int, shuffleWebSocketPort int, torShuf
 		banData:                 make(map[string]*banData),
 		connections:             make(map[net.Conn]*playerData),
 		verificationKeys:        make(map[string]net.Conn),
-		denyIPMatch:             make(map[string]map[string]time.Time),
+		denyIPMatch:             make(map[ipPair]time.Time),
 		pools:                   make(map[int]map[uint32]*playerData),
 		poolAmounts:             make(map[int]uint64),
 		poolVoters:              make(map[int]int),
@@ -148,24 +161,14 @@ func (t *Tracker) addDenyIPMatch(player1 net.Conn, pool int) {
 	defer t.mutex.Unlock()
 
 	ip, _, _ := net.SplitHostPort(player1.RemoteAddr().String())
-	if _, ok := t.denyIPMatch[ip]; !ok {
-		t.denyIPMatch[ip] = make(map[string]time.Time)
-	}
-
 	for _, otherPlayer := range t.pools[pool] {
 		otherIP, _, _ := net.SplitHostPort(otherPlayer.conn.RemoteAddr().String())
-
 		if ip == otherIP {
 			continue
 		}
 
-		if _, ok := t.denyIPMatch[otherIP]; !ok {
-			t.denyIPMatch[otherIP] = make(map[string]time.Time)
-		}
-
-		// Tracking on two keys for faster lookup later.
-		t.denyIPMatch[ip][otherIP] = time.Now()
-		t.denyIPMatch[otherIP][ip] = time.Now()
+		// if a ban somehow already exists, extend it
+		t.denyIPMatch[newIPPair(ip, otherIP)] = time.Now()
 	}
 }
 
@@ -173,13 +176,10 @@ func (t *Tracker) addDenyIPMatch(player1 net.Conn, pool int) {
 // Caller should hold the mutex.
 func (t *Tracker) deniedByIPMatch(player net.Conn, pool int) bool {
 	ip, _, _ := net.SplitHostPort(player.RemoteAddr().String())
-	if _, ok := t.denyIPMatch[ip]; !ok {
-		return false
-	}
-
 	for _, otherPlayer := range t.pools[pool] {
 		otherIP, _, _ := net.SplitHostPort(otherPlayer.conn.RemoteAddr().String())
-		if _, ok := t.denyIPMatch[ip][otherIP]; ok {
+
+		if _, ok := t.denyIPMatch[newIPPair(ip, otherIP)]; ok {
 			return true
 		}
 	}
@@ -192,11 +192,9 @@ func (t *Tracker) CleanupDeniedByIPMatch() {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	for ip, deniedIPs := range t.denyIPMatch {
-		for deniedIP, deniedTime := range deniedIPs {
-			if deniedTime.Add(denyIPTime).Before(time.Now()) {
-				delete(t.denyIPMatch[ip], deniedIP)
-			}
+	for pair, deniedTime := range t.denyIPMatch {
+		if deniedTime.Add(denyIPTime).Before(time.Now()) {
+			delete(t.denyIPMatch, pair)
 		}
 	}
 }


### PR DESCRIPTION
In my opinion, this makes the new code (which is nice) slightly easier to follow and maintain in the future:

- less overall code/logic for reversible lookups
- more shallow loops

 The changes shift time and space complexity around a bit. The worst spot is in the pool check - it can't use the short circuit at the beginning of the loop. However on the positive side it uses less space for each pair and less lookups for basic operations. Overall I think the complexity change can be ignored either way.

I know it's not so complicated in the first place, but this is how I imagined it when I first heard the idea so I thought I would put it out there for consideration.