### PR TITLE
ensure tests fail fast

### DIFF
--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -349,6 +349,7 @@ func (inbox *testInbox) PopOldest() (*packetInfo, error) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	return packet, err
 }
@@ -437,12 +438,14 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 
 			// confirm both sides of connection are closed
 			if c.conn != nil {
+				_ = c.conn.SetReadDeadline(time.Now())
 				_, err := c.conn.Read([]byte{})
 				if (err != io.EOF) && (err != io.ErrClosedPipe) {
 					return fmt.Errorf("client side of connection still active")
 				}
 			}
 			if c.remoteConn != nil {
+				_ = c.remoteConn.SetReadDeadline(time.Now())
 				_, err := c.remoteConn.Read([]byte{})
 				if (err != io.EOF) && (err != io.ErrClosedPipe) {
 					return fmt.Errorf("server side of connection still active")
@@ -453,6 +456,7 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	if err != nil {
 		h.t.Fatal(err)
@@ -568,6 +572,7 @@ func (h *testHarness) WaitEmptyInboxes(clients []*testClient) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	if err != nil {
 		h.t.Fatal(err)

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -428,6 +428,17 @@ func (h *testHarness) WaitBroadcastBlame(expected *message.Signed, pool []*testC
 func (h *testHarness) WaitNotConnected(c *testClient) {
 	err := retry.Do(
 		func() error {
+			// confirm client side of the connection is closed
+			if c.conn != nil {
+				_ = c.conn.SetReadDeadline(time.Now())
+				_, err := c.conn.Read([]byte{})
+				if (err != io.EOF) && (err != io.ErrClosedPipe) {
+					return fmt.Errorf("client side of connection still active")
+				}
+				c.conn = nil
+			}
+
+			// then make sure the server drops the client from the tracker
 			h.tracker.mutex.RLock()
 			defer h.tracker.mutex.RUnlock()
 			// confirm removed from connection lookup
@@ -436,21 +447,6 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 				return fmt.Errorf("server thinks client is still connected")
 			}
 
-			// confirm both sides of connection are closed
-			if c.conn != nil {
-				_ = c.conn.SetReadDeadline(time.Now())
-				_, err := c.conn.Read([]byte{})
-				if (err != io.EOF) && (err != io.ErrClosedPipe) {
-					return fmt.Errorf("client side of connection still active")
-				}
-			}
-			if c.remoteConn != nil {
-				_ = c.remoteConn.SetReadDeadline(time.Now())
-				_, err := c.remoteConn.Read([]byte{})
-				if (err != io.EOF) && (err != io.ErrClosedPipe) {
-					return fmt.Errorf("server side of connection still active")
-				}
-			}
 			// all evidence says client is disconnected
 			return nil
 		},

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -422,8 +422,8 @@ func (h *testHarness) WaitBroadcastBlame(expected *message.Signed, pool []*testC
 	}
 }
 
-// WaitNotConnected confirms that both sides of the client connection are closed
-// and that client's connection is not in the server's lookup table.
+// WaitNotConnected confirms that client's connection is not
+// in the server's lookup table.
 func (h *testHarness) WaitNotConnected(c *testClient) {
 	err := retry.Do(
 		func() error {


### PR DESCRIPTION
Two things.

- The tests were using a backoff strategy by default which caused them to wait much longer than they should. Changed to a fixed delay.
- the `WaitNotConnected()` method was interfering with both client and server side connections directly, thus interfering with the real behavior. I removed all effects so that the wait is only observing the server, and made sure that it will fail in a reasonable amount of time if the disconnect does not work.
