### PR TITLE
Allow players to be blamed even after disconnecting

### DIFF
--- a/server/banned.go
+++ b/server/banned.go
@@ -44,20 +44,20 @@ func (pi *packetInfo) checkBlameMessage() error {
 	}
 
 	if validBlame {
-		accusedKey := packet.Message.Blame.Accused.String()
-		accused := pi.tracker.playerByVerificationKey(accusedKey)
-
-		if accused == nil {
-			return nil
-		}
-
 		blamer := pi.tracker.playerByConnection(pi.conn)
 		if blamer == nil {
 			return nil
 		}
 
+		accusedKey := packet.Message.Blame.Accused.String()
+		players := pi.tracker.blameablePlayers(blamer.pool)
+		accused := players[accusedKey]
+		if accused == nil {
+			return errors.New("invalid blame")
+		}
+
 		if accused.pool != blamer.pool {
-			return errors.New("invalid ban")
+			return errors.New("invalid blame")
 		}
 
 		added := accused.addBlame(blamer.verificationKey)

--- a/server/banned.go
+++ b/server/banned.go
@@ -50,8 +50,7 @@ func (pi *packetInfo) checkBlameMessage() error {
 		}
 
 		accusedKey := packet.Message.Blame.Accused.String()
-		players := pi.tracker.blameablePlayers(blamer.pool)
-		accused := players[accusedKey]
+		accused := pi.tracker.fullPoolSnapshot[blamer.pool][accusedKey]
 		if accused == nil {
 			return errors.New("invalid blame")
 		}

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -349,6 +349,7 @@ func (inbox *testInbox) PopOldest() (*packetInfo, error) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	return packet, err
 }
@@ -437,12 +438,14 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 
 			// confirm both sides of connection are closed
 			if c.conn != nil {
+				_ = c.conn.SetReadDeadline(time.Now())
 				_, err := c.conn.Read([]byte{})
 				if (err != io.EOF) && (err != io.ErrClosedPipe) {
 					return fmt.Errorf("client side of connection still active")
 				}
 			}
 			if c.remoteConn != nil {
+				_ = c.remoteConn.SetReadDeadline(time.Now())
 				_, err := c.remoteConn.Read([]byte{})
 				if (err != io.EOF) && (err != io.ErrClosedPipe) {
 					return fmt.Errorf("server side of connection still active")
@@ -453,6 +456,7 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	if err != nil {
 		h.t.Fatal(err)
@@ -568,6 +572,7 @@ func (h *testHarness) WaitEmptyInboxes(clients []*testClient) {
 		},
 		retry.Attempts(100),
 		retry.Delay(5*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
 	)
 	if err != nil {
 		h.t.Fatal(err)

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -428,6 +428,17 @@ func (h *testHarness) WaitBroadcastBlame(expected *message.Signed, pool []*testC
 func (h *testHarness) WaitNotConnected(c *testClient) {
 	err := retry.Do(
 		func() error {
+			// confirm client side of the connection is closed
+			if c.conn != nil {
+				_ = c.conn.SetReadDeadline(time.Now())
+				_, err := c.conn.Read([]byte{})
+				if (err != io.EOF) && (err != io.ErrClosedPipe) {
+					return fmt.Errorf("client side of connection still active")
+				}
+				c.conn = nil
+			}
+
+			// then make sure the server drops the client from the tracker
 			h.tracker.mutex.RLock()
 			defer h.tracker.mutex.RUnlock()
 			// confirm removed from connection lookup
@@ -436,21 +447,6 @@ func (h *testHarness) WaitNotConnected(c *testClient) {
 				return fmt.Errorf("server thinks client is still connected")
 			}
 
-			// confirm both sides of connection are closed
-			if c.conn != nil {
-				_ = c.conn.SetReadDeadline(time.Now())
-				_, err := c.conn.Read([]byte{})
-				if (err != io.EOF) && (err != io.ErrClosedPipe) {
-					return fmt.Errorf("client side of connection still active")
-				}
-			}
-			if c.remoteConn != nil {
-				_ = c.remoteConn.SetReadDeadline(time.Now())
-				_, err := c.remoteConn.Read([]byte{})
-				if (err != io.EOF) && (err != io.ErrClosedPipe) {
-					return fmt.Errorf("server side of connection still active")
-				}
-			}
 			// all evidence says client is disconnected
 			return nil
 		},

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -60,15 +60,24 @@ func TestUnanimousBlamesLeadToServerBan(t *testing.T) {
 
 		// all but one other client blames troubleClient
 		otherClients[0].Blame(troubleClient, allClients)
-		otherClients[1].Blame(troubleClient, allClients)
+
+		// troubleClient tries to avoid blame by disconnecting!
+		// It should not work - troubleClient should still be banned eventually.
+		troubleClient.Disconnect()
+
+		// Blames continue.
+		// Also since troubleClient disconnected, we only expect notifications
+		// to go to remaining clients.
+		otherClients[1].Blame(troubleClient, otherClients)
+
 		// duplicate blames from the same client should not be counted twice!
-		otherClients[2].Blame(troubleClient, allClients)
-		otherClients[2].Blame(troubleClient, allClients)
+		otherClients[2].Blame(troubleClient, otherClients)
+		otherClients[2].Blame(troubleClient, otherClients)
+
 		// ban score does not change yet because it is not a unanimous vote
 		h.AssertServerBans(expectedBanData)
 		// the last other client also blames troubleClient
-		// this should cause troubleClient to be banned from the current
-		// pool and not receive the notification
+		// this should cause troubleClient to be banned from the current pool
 		otherClients[3].Blame(troubleClient, otherClients)
 		// troubleClient also gets a new or increased ban score
 		// because this is now a unanimous vote

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -46,7 +46,7 @@ type Tracker struct {
 	poolTypes               map[int]message.ShuffleType
 	poolSize                int
 	fullPools               map[int]interface{}
-	poolDisconnectedCache   map[int]map[string]*playerData  // pool > vk > player
+	poolDisconnectedCache   map[int]map[string]*playerData // pool > vk > player
 	shufflePort             int
 	shuffleWebSocketPort    int
 	torShufflePort          int

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -376,18 +376,11 @@ func (t *Tracker) unassignPool(p *playerData) {
 }
 
 // takePoolSnapshot gets a lookup of all players in the pool
+// This method assumes the caller is holding the mutex.
 func (t *Tracker) takePoolSnapshot(n int) map[string]*playerData {
 	snapshot := make(map[string]*playerData)
 	for _, p := range t.pools[n] {
 		snapshot[p.verificationKey] = p
 	}
 	return snapshot
-}
-
-// addToDisconnectedCache tracks a user that disconnected from a pool
-func (t *Tracker) addToDisconnectedCache(p *playerData) {
-	if t.fullPoolSnapshot[p.pool] == nil {
-		t.fullPoolSnapshot[p.pool] = make(map[string]*playerData)
-	}
-	t.fullPoolSnapshot[p.pool][p.verificationKey] = p
 }


### PR DESCRIPTION
Fixes #52

- In this PR, players can connect and disconnect from a pool as much as they want.
- However after a pool is full, it tracks players even after they disconnect from the pool.
- Any blames can still be applied to their IP after they disconnect.
- When the pool is dissolved, it also dissolves the disconnected cache.

It can be argued that this also solves #46 without needing to track a new disconnect score. It would not catch people who are connecting and disconnecting repeatedly before a pool becomes full. Eventually those users will end up in full pools and get blamed so it catches this type of user eventually.