### PR TITLE
[Chore] Use Get functions on protobuf messages

### DIFF
--- a/server/banned.go
+++ b/server/banned.go
@@ -28,18 +28,14 @@ func (pi *packetInfo) checkBlameMessage() error {
 	pkt := pi.message.Packet[0]
 	packet := pkt.GetPacket()
 
-	if packet.Message == nil {
-		return nil
-	}
-
-	if packet.Message.Blame == nil {
+	if packet.GetMessage().GetBlame() == nil {
 		return nil
 	}
 
 	validBlame := false
 
 	for _, reason := range validBlamereasons {
-		if packet.Message.Blame.Reason == reason {
+		if packet.GetMessage().GetBlame().GetReason() == reason {
 			validBlame = true
 		}
 	}
@@ -49,7 +45,7 @@ func (pi *packetInfo) checkBlameMessage() error {
 		if blamer == nil {
 			return nil
 		}
-		accusedKey := packet.Message.Blame.Accused.String()
+		accusedKey := packet.GetMessage().GetBlame().GetAccused().GetKey()
 		accused := blamer.pool.PlayerFromSnapshot(accusedKey)
 		if accused == nil {
 			return errors.New("invalid blame")

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -23,7 +23,7 @@ func (pi *packetInfo) broadcastMessage() {
 		if to == nil {
 			msgMap[broadcastKey] = append(msgMap[broadcastKey], signed)
 		} else {
-			k := fmt.Sprintf("%s%s", playerPrefix, signed.GetPacket().GetToKey().String())
+			k := fmt.Sprintf("%s%s", playerPrefix, signed.GetPacket().GetToKey().GetKey())
 			msgMap[k] = append(msgMap[k], signed)
 		}
 	}

--- a/server/register.go
+++ b/server/register.go
@@ -17,7 +17,7 @@ func (pi *packetInfo) registerClient() error {
 			p := signed.GetPacket()
 			registration := p.GetRegistration()
 
-			verificationKey := p.FromKey.String()
+			verificationKey := p.GetFromKey().GetKey()
 			player = pi.tracker.playerByVerificationKey(verificationKey)
 			if player != nil {
 				return fmt.Errorf("server already has a player "+

--- a/server/verification.go
+++ b/server/verification.go
@@ -18,7 +18,7 @@ func (pi *packetInfo) verifyMessage() error {
 			return errors.New("invalid session")
 		}
 
-		if packet.GetFromKey().String() != player.verificationKey {
+		if packet.GetFromKey().GetKey() != player.verificationKey {
 			return errors.New("invalid verification key")
 		}
 
@@ -28,7 +28,7 @@ func (pi *packetInfo) verifyMessage() error {
 
 		to := packet.GetToKey()
 		if to != nil {
-			if pi.tracker.playerByVerificationKey(to.String()) == nil {
+			if pi.tracker.playerByVerificationKey(to.GetKey()) == nil {
 				return errors.New("invalid destination")
 			}
 		}


### PR DESCRIPTION
This just updates the codebase to use the protobuf Get methods. I noticed that verification keys were being prefixed with `key:` and that while the logic was correct, the values were not quite what I expected.

Now verification keys won't be prefixed, and will be the raw values. It also allows us to chain commands in a safer way.

Let me know what you think. 