### PR TITLE
Remove call to t.addDenyIPMatch in Tracker unassignPool()

### DIFF
--- a/server/tracker.go
+++ b/server/tracker.go
@@ -300,7 +300,7 @@ func (t *Tracker) unassignPool(p *PlayerData) {
 	if p.isPassive {
 		t.increaseBanScore(p.conn, true)
 		if debugMode {
-			fmt.Printf("[DenyIP] Passive user disconnected: %s\n", p.verificationKey)
+			fmt.Printf("[DenyIP] Passive user disconnected: %s (IP: %s)\n", p.verificationKey, p.conn.RemoteAddr().String())
 		}
 		// NB: this has been taken out for now until we can better characterize
 		// how often this happens and/or if it would do more harm than good. -Calin

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -302,7 +302,9 @@ func (t *Tracker) unassignPool(p *PlayerData) {
 		if debugMode {
 			fmt.Printf("[DenyIP] Passive user disconnected: %s\n", p.verificationKey)
 		}
-		t.addDenyIPMatch(p.conn, p.pool, true)
+		// NB: this has been taken out for now until we can better characterize
+		// how often this happens and/or if it would do more harm than good. -Calin
+		//t.addDenyIPMatch(p.conn, p.pool, true)
 	}
 
 	pool := p.pool


### PR DESCRIPTION
I recommend we take this out until we can understand its impact better by studying the logs.

Server's been running all day off my fork with it removed and we haven't had any issues. 

Thanks.