### PR TITLE
help honest clients-send all blames including last one to banned player

### DIFF
--- a/server/banned.go
+++ b/server/banned.go
@@ -77,7 +77,6 @@ func (pi *packetInfo) checkBlameMessage() error {
 				fmt.Printf("[DenyIP] User blamed out of round: %s\n", accused.verificationKey)
 			}
 			pi.tracker.addDenyIPMatch(accused.conn, accused.pool, false)
-			pi.tracker.remove(accused.conn)
 		}
 	}
 

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -107,8 +107,6 @@ func TestUnanimousBlamesLeadToServerBan(t *testing.T) {
 			expectedBanData[0].banData.score++
 		}
 		h.AssertServerBans(expectedBanData)
-		// troubleClient should be actively disconnected from the server
-		h.WaitNotConnected(troubleClient)
 
 		// remaining players try to blame one of themselves, but the pool
 		// only allows one ban even with a full vote.


### PR DESCRIPTION
Fixes #72 

I don't see anywhere that `PlayerCount()` or other logic will be impacted by leaving the blamed player in the pool. For example we use `firstBan` to track the voting status explicitly - so the banned player still sitting in the pool should not cause a problem.

The worst case I can think of is that the banned player is malicious and spamming but I think that would be better to solve directly with a [more strict specification](https://github.com/cashshuffle/spec/issues/3) that that lets the server and clients immediately identify a misbehaving client.

@alwaysAn0n thanks for the discussion leading to this.