### PR TITLE
Point to the new spec from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 [![License][License-Image]][License-URL] [![ReportCard][ReportCard-Image]][ReportCard-URL] [![Build][Build-Status-Image]][Build-Status-URL]
 # cashshuffle
 
-A CashShuffle server implented in Go. For more information on CashShuffle visit [https://cashshuffle.com](https://cashshuffle.com).
+A CashShuffle server implented in Go.
+
+For more information on CashShuffle visit [cashshuffle.com](https://cashshuffle.com).
+
+Technical specification and documentation are at [github.com/cashshuffle/spec](https://github.com/cashshuffle/spec).
 
 ## Install
 


### PR DESCRIPTION
Point to the new spec directly from the readme.


@zquestz :

- We can also delete the wiki for now - I slightly updated the wiki information and all of it is included on the new spec repo. Do you mind if I do that?
- The github display link was very long with `https://` so I removed https from the display (not from the link itself) for both github and the cashshuffle site. Obviously I can change all of that to whatever works - please let me know if you you have a preference.
