### PR TITLE
Add additional headers to stats endpoint response

### DIFF
--- a/server/stats_server.go
+++ b/server/stats_server.go
@@ -39,6 +39,8 @@ func statsJSON(si StatsInformer, tor bool) func(http.ResponseWriter, *http.Reque
 		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 		b, _ := json.Marshal(si.Stats(ip, tor))
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
 		w.Write(b)
 	}
 }


### PR DESCRIPTION
These changes allow in-browser CashShuffle clients to use public CashShuffle clients.  I can imagine many reasons why you'd want to do this.  The most obvious being it allows for shuffling to be added to repos like `https://github.com/theantnest/bccaddress` where the user is expected to run the code locally in their browser for safety reasons.